### PR TITLE
perf: use registry based key for node children

### DIFF
--- a/packages/prosemirror-react-view/src/components/editor.tsx
+++ b/packages/prosemirror-react-view/src/components/editor.tsx
@@ -5,7 +5,7 @@ import React, { memo, NamedExoticComponent, SyntheticEvent } from 'react';
 import { DOMSerializerProvider } from '../dom-serializer/context';
 import { useEditorState } from '../hooks/useEditor';
 import { PMEditorProps } from '../types';
-import { map } from '../utils';
+import { getNodeKey, map } from '../utils';
 import { EditorNode } from './editor-node';
 
 export interface EditorProps {
@@ -43,7 +43,6 @@ export const Editor: NamedExoticComponent<EditorProps> = memo(({ schema, initial
   if (!editorState) {
     return null;
   }
-  let index = 0;
   return (
     <DOMSerializerProvider schema={schema} plugins={plugins}>
       <div
@@ -78,18 +77,17 @@ export const Editor: NamedExoticComponent<EditorProps> = memo(({ schema, initial
             apply(tr);
           }
 
-          event.preventDefault();
-        }}
-        onKeyUp={preventDefault}
-        onSelect={preventDefault}
-        suppressContentEditableWarning
-      >
-        {/* We dont render root doc because doesnt contain toDOM */}
-        {map(editorState.doc, child => (
-          <EditorNode node={child} key={index++} />
-        ))}
-      </div>
-    </DOMSerializerProvider>
+        event.preventDefault();
+      }}
+      onKeyUp={preventDefault}
+      onSelect={preventDefault}
+      suppressContentEditableWarning
+    >
+      {/* We dont render root doc because doesn't contain toDOM */}
+      {map(editorState.doc, child => (
+        <EditorNode node={child} key={getNodeKey(child)} />
+      ))}
+    </div>
   );
 });
 

--- a/packages/prosemirror-react-view/src/utils.ts
+++ b/packages/prosemirror-react-view/src/utils.ts
@@ -8,3 +8,17 @@ export function map<T>(
   node.forEach((node1, offset, index) => mappedContent.push(fn(node1, offset, index)));
   return mappedContent;
 }
+
+let nodeKey = 0;
+const nodeMap = new WeakMap<ProsemirrorNode<any>, number>();
+
+export function getNodeKey(node: ProsemirrorNode<any>): number {
+  const savedKey = nodeMap.get(node);
+
+  if (typeof savedKey !== 'undefined') {
+    return savedKey;
+  }
+
+  nodeMap.set(node, nodeKey++);
+  return nodeKey;
+}


### PR DESCRIPTION
This changes the source of `key` for nodes from the relevant index to a `WeakMap` based registry.